### PR TITLE
refactor(config): Track public coach profile #15

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
+# Public coach profile values live in src/content/site.ts so they can be committed.
+# Keep only environment-specific values and secrets in .env.local.
+
 # Site
 SITE_URL=http://localhost:3000
-COACH_NAME=Your Name
-COACH_CITY=Your City
-COACH_EMAIL=coach@example.com
 COACH_IG_USERNAME=your_ig_handle
 BOOKING_URL=
 

--- a/LICENSE-CONTENT
+++ b/LICENSE-CONTENT
@@ -11,7 +11,7 @@ are not licensed under the Apache License 2.0 and remain proprietary:
 
 - files in `src/content/`
 - custom branding, image, and media assets in `public/`
-- the Boulder Daddy name, logos, wordmarks, and other branding
+- the mathemage name, logos, wordmarks, and other branding
 - written site copy, testimonials, pricing information, and editorial content
 - photographs, images, graphics, and other media assets
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ src/
 │   └── ContactForm.tsx     # Contact form with validation
 ├── content/                # Content data (easy to edit)
 │   ├── services.ts         # Coaching offerings
+│   ├── site.ts             # Public coach profile data
 │   ├── pricing.ts          # Pricing tiers
 │   ├── testimonials.ts     # Client testimonials
 │   ├── faqs.ts             # FAQ entries
@@ -96,20 +97,19 @@ src/
 
 ## Configuration
 
-Copy `.env.example` to `.env.local` and update the values:
+Copy `.env.example` to `.env.local` and update the environment-specific values:
 
 ```bash
 cp .env.example .env.local
 ```
+
+Public coach profile values (name, city, and email) live in `src/content/site.ts` so they can be versioned with the rest of your site content.
 
 ### Environment Variables
 
 | Variable                       | Required | Description                                                           |
 | ------------------------------ | -------- | --------------------------------------------------------------------- |
 | `SITE_URL`                     | Yes      | Your site URL (e.g., `https://yourdomain.com`)                        |
-| `COACH_NAME`                   | Yes      | Your name as displayed on the site                                    |
-| `COACH_CITY`                   | Yes      | Your city/location                                                    |
-| `COACH_EMAIL`                  | Yes      | Your contact email                                                    |
 | `COACH_IG_USERNAME`            | Yes      | Your Instagram handle                                                 |
 | `BOOKING_URL`                  | No       | External booking link (shows "Book a Session" button if set)          |
 | `INSTAGRAM_MODE`               | Yes      | `manual`, `proxy`, or `graph`                                         |
@@ -153,6 +153,7 @@ If proxy or Graph API calls fail, the service automatically falls back to manual
 
 All site content lives in `src/content/`:
 
+- **Site profile**: Edit `site.ts` to set your public coach name, city, and email
 - **Services**: Edit `services.ts` to add/remove/modify coaching offerings
 - **Pricing**: Edit `pricing.ts` to update tiers and features
 - **Testimonials**: Edit `testimonials.ts` to add client stories
@@ -209,7 +210,7 @@ pnpm test:watch   # Run tests in watch mode
 
 ## TODOs
 
-- [ ] Set your real coach name, city, and email in `.env.local`
+- [x] Set your real coach name, city, and email in `src/content/site.ts`
 - [ ] Replace placeholder Instagram posts in `src/content/instagram.json` with real content
 - [ ] Configure Instagram Graph API (optional — set env vars)
 - [ ] Set up email provider (Resend, SendGrid, etc.) in `src/lib/email/index.ts`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Boulder Daddy
+# mathemage
 
 [![CI](https://github.com/mathemage/boulder-daddy/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mathemage/boulder-daddy/actions/workflows/ci.yml)
 [![Code: Apache-2.0](https://img.shields.io/badge/Code-Apache%202.0-blue.svg)](https://choosealicense.com/licenses/apache-2.0/)
@@ -103,7 +103,7 @@ Copy `.env.example` to `.env.local` and update the environment-specific values:
 cp .env.example .env.local
 ```
 
-Public coach profile values (name, city, and email) live in `src/content/site.ts` so they can be versioned with the rest of your site content.
+Public branding and coach profile values (brand name, coach name, city, and email) live in `src/content/site.ts` so they can be versioned with the rest of your site content.
 
 ### Environment Variables
 
@@ -153,7 +153,7 @@ If proxy or Graph API calls fail, the service automatically falls back to manual
 
 All site content lives in `src/content/`:
 
-- **Site profile**: Edit `site.ts` to set your public coach name, city, and email
+- **Site profile**: Edit `site.ts` to set your public brand name, coach name, city, and email
 - **Services**: Edit `services.ts` to add/remove/modify coaching offerings
 - **Pricing**: Edit `pricing.ts` to update tiers and features
 - **Testimonials**: Edit `testimonials.ts` to add client stories
@@ -229,5 +229,5 @@ See [LICENSE-CONTENT](./LICENSE-CONTENT) for the proprietary notice. This
 includes `src/content/` and any custom project assets in `public/` unless a
 file states otherwise.
 
-Apache-2.0 also does not grant trademark rights in the Boulder Daddy name
+Apache-2.0 also does not grant trademark rights in the mathemage name
 or branding. Third-party assets remain subject to their own terms.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next';
 import { CTAButton } from '@/components/CTAButton';
-import { env } from '@/lib/env';
+import { siteConfig } from '@/content/site';
 
 export const metadata: Metadata = {
   title: 'About',
-  description: `Learn about ${env.coachName} — professional bouldering coach in ${env.coachCity}. Coaching philosophy, safety practices, and certifications.`,
+  description: `Learn about ${siteConfig.coachName} — professional bouldering coach in ${siteConfig.coachCity}. Coaching philosophy, safety practices, and certifications.`,
 };
 
 export default function AboutPage() {
@@ -33,8 +33,8 @@ export default function AboutPage() {
               climbers of every level move better, progress consistently, and enjoy the process.
             </p>
             <p>
-              I&apos;m based in {env.coachCity} and coach at several local gyms as well as outdoor
-              crags in the surrounding area.
+              I&apos;m based in {siteConfig.coachCity} and coach at several local gyms as well as
+              outdoor crags in the surrounding area.
             </p>
           </div>
         </div>

--- a/src/app/coaching/page.tsx
+++ b/src/app/coaching/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next';
 import { services } from '@/content/services';
+import { siteConfig } from '@/content/site';
 import { CTAButton } from '@/components/CTAButton';
-import { env } from '@/lib/env';
 
 export const metadata: Metadata = {
   title: 'Coaching',
-  description: `Bouldering coaching services in ${env.coachCity}. From beginner fundamentals to advanced project coaching — find the right session for your level.`,
+  description: `Bouldering coaching services in ${siteConfig.coachCity}. From beginner fundamentals to advanced project coaching — find the right session for your level.`,
 };
 
 export default function CoachingPage() {
@@ -15,8 +15,8 @@ export default function CoachingPage() {
       <section className="bg-slate-900 px-4 py-20 text-center text-white">
         <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">Coaching</h1>
         <p className="mx-auto max-w-2xl text-lg text-slate-300">
-          Personalised bouldering coaching designed to meet you where you are and take you where
-          you want to go.
+          Personalised bouldering coaching designed to meet you where you are and take you where you
+          want to go.
         </p>
       </section>
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
 import { ContactForm } from '@/components/ContactForm';
+import { siteConfig } from '@/content/site';
 import { env } from '@/lib/env';
 
 export const metadata: Metadata = {
   title: 'Contact',
-  description: `Get in touch with ${env.coachName} for bouldering coaching inquiries in ${env.coachCity}. Book a session or ask a question.`,
+  description: `Get in touch with ${siteConfig.coachName} for bouldering coaching inquiries in ${siteConfig.coachCity}. Book a session or ask a question.`,
 };
 
 export default function ContactPage() {
@@ -13,8 +14,8 @@ export default function ContactPage() {
       <section className="bg-slate-900 px-4 py-20 text-center text-white">
         <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">Get in Touch</h1>
         <p className="mx-auto max-w-2xl text-lg text-slate-300">
-          Ready to start climbing smarter? Fill out the form below and I will get back to you
-          within 24 hours.
+          Ready to start climbing smarter? Fill out the form below and I will get back to you within
+          24 hours.
         </p>
       </section>
 
@@ -24,10 +25,10 @@ export default function ContactPage() {
             <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
               <h3 className="mb-1 text-sm font-bold text-slate-900">Email</h3>
               <a
-                href={`mailto:${env.coachEmail}`}
+                href={`mailto:${siteConfig.coachEmail}`}
                 className="text-sm text-slate-600 hover:text-slate-900"
               >
-                {env.coachEmail}
+                {siteConfig.coachEmail}
               </a>
             </div>
             <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,14 +8,14 @@ import './globals.css';
 export const metadata: Metadata = {
   metadataBase: new URL(env.siteUrl),
   title: {
-    default: `${siteConfig.coachName} — Bouldering Coach in ${siteConfig.coachCity}`,
-    template: `%s | ${siteConfig.coachName}`,
+    default: `${siteConfig.brandName} — Bouldering Coach in ${siteConfig.coachCity}`,
+    template: `%s | ${siteConfig.brandName}`,
   },
   description: `Professional bouldering and climbing coaching in ${siteConfig.coachCity}. Improve your technique, send harder grades, and stay injury-free with personalised coaching from ${siteConfig.coachName}.`,
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    siteName: siteConfig.coachName,
+    siteName: siteConfig.brandName,
   },
   twitter: {
     card: 'summary_large_image',
@@ -31,6 +31,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     '@context': 'https://schema.org',
     '@type': ['LocalBusiness', 'Person'],
     name: siteConfig.coachName,
+    alternateName: siteConfig.brandName,
     description: `Professional bouldering coach in ${siteConfig.coachCity}`,
     url: env.siteUrl,
     email: siteConfig.coachEmail,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,20 +1,21 @@
 import type { Metadata } from 'next';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
+import { siteConfig } from '@/content/site';
 import { env } from '@/lib/env';
 import './globals.css';
 
 export const metadata: Metadata = {
   metadataBase: new URL(env.siteUrl),
   title: {
-    default: `${env.coachName} — Bouldering Coach in ${env.coachCity}`,
-    template: `%s | ${env.coachName}`,
+    default: `${siteConfig.coachName} — Bouldering Coach in ${siteConfig.coachCity}`,
+    template: `%s | ${siteConfig.coachName}`,
   },
-  description: `Professional bouldering and climbing coaching in ${env.coachCity}. Improve your technique, send harder grades, and stay injury-free with personalised coaching from ${env.coachName}.`,
+  description: `Professional bouldering and climbing coaching in ${siteConfig.coachCity}. Improve your technique, send harder grades, and stay injury-free with personalised coaching from ${siteConfig.coachName}.`,
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    siteName: env.coachName,
+    siteName: siteConfig.coachName,
   },
   twitter: {
     card: 'summary_large_image',
@@ -29,13 +30,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': ['LocalBusiness', 'Person'],
-    name: env.coachName,
-    description: `Professional bouldering coach in ${env.coachCity}`,
+    name: siteConfig.coachName,
+    description: `Professional bouldering coach in ${siteConfig.coachCity}`,
     url: env.siteUrl,
-    email: env.coachEmail,
+    email: siteConfig.coachEmail,
     address: {
       '@type': 'PostalAddress',
-      addressLocality: env.coachCity,
+      addressLocality: siteConfig.coachCity,
     },
     sameAs: [`https://instagram.com/${env.coachIgUsername}`],
   };

--- a/src/app/legal/licensing/page.tsx
+++ b/src/app/legal/licensing/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
+import { siteConfig } from '@/content/site';
 
 const LAST_UPDATED = 'March 2026';
 
 export const metadata: Metadata = {
   title: 'Licensing',
-  description: 'License summary for the Boulder Daddy website code, branding, content, and media.',
+  description: `License summary for the ${siteConfig.brandName} website code, branding, content, and media.`,
 };
 
 export default function LicensingPage() {
@@ -50,8 +51,8 @@ export default function LicensingPage() {
 
           <h2 className="mb-4 text-xl font-bold text-slate-900">Trademarks</h2>
           <p>
-            No trademark or branding rights are granted in the Boulder Daddy name, logos, or other
-            brand assets. Third-party assets remain subject to their own terms.
+            No trademark or branding rights are granted in the {siteConfig.brandName} name, logos,
+            or other brand assets. Third-party assets remain subject to their own terms.
           </p>
         </div>
       </section>

--- a/src/app/legal/privacy/page.tsx
+++ b/src/app/legal/privacy/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next';
-import { env } from '@/lib/env';
+import { siteConfig } from '@/content/site';
 
 const LAST_UPDATED = 'March 2026';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy',
-  description: `Privacy policy for ${env.coachName}'s coaching website.`,
+  description: `Privacy policy for ${siteConfig.coachName}'s coaching website.`,
 };
 
 export default function PrivacyPage() {
@@ -43,8 +43,8 @@ export default function PrivacyPage() {
 
           <h2 className="mb-4 text-xl font-bold text-slate-900">4. Cookies</h2>
           <p className="mb-6">
-            This website uses only essential cookies required for the site to function. If
-            analytics are enabled, they use privacy-friendly, cookieless tracking.
+            This website uses only essential cookies required for the site to function. If analytics
+            are enabled, they use privacy-friendly, cookieless tracking.
           </p>
 
           <h2 className="mb-4 text-xl font-bold text-slate-900">5. Third-Party Services</h2>
@@ -58,8 +58,8 @@ export default function PrivacyPage() {
           <p className="mb-6">
             You have the right to request access to, correction of, or deletion of your personal
             data. To exercise these rights, please contact{' '}
-            <a href={`mailto:${env.coachEmail}`} className="text-slate-900 underline">
-              {env.coachEmail}
+            <a href={`mailto:${siteConfig.coachEmail}`} className="text-slate-900 underline">
+              {siteConfig.coachEmail}
             </a>
             .
           </p>
@@ -67,8 +67,8 @@ export default function PrivacyPage() {
           <h2 className="mb-4 text-xl font-bold text-slate-900">7. Contact</h2>
           <p>
             If you have questions about this privacy policy, please email{' '}
-            <a href={`mailto:${env.coachEmail}`} className="text-slate-900 underline">
-              {env.coachEmail}
+            <a href={`mailto:${siteConfig.coachEmail}`} className="text-slate-900 underline">
+              {siteConfig.coachEmail}
             </a>
             .
           </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { ServiceCards } from '@/components/ServiceCards';
 import { InstagramGallery } from '@/components/InstagramGallery';
 import { Testimonials } from '@/components/Testimonials';
 import { CTAButton } from '@/components/CTAButton';
+import { siteConfig } from '@/content/site';
 import { env } from '@/lib/env';
 import { getInstagramPosts } from '@/lib/instagram';
 
@@ -11,7 +12,7 @@ export default async function HomePage() {
 
   return (
     <>
-      <Hero coachCity={env.coachCity} />
+      <Hero coachCity={siteConfig.coachCity} />
       <ServiceCards />
       <InstagramGallery posts={posts} coachIgUsername={env.coachIgUsername} />
       <Testimonials />

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next';
 import { PricingTable } from '@/components/PricingTable';
 import { FAQ } from '@/components/FAQ';
-import { env } from '@/lib/env';
+import { siteConfig } from '@/content/site';
 
 export const metadata: Metadata = {
   title: 'Pricing',
-  description: `Bouldering coaching pricing in ${env.coachCity}. Flexible single sessions, multi-session packs, and monthly programmes.`,
+  description: `Bouldering coaching pricing in ${siteConfig.coachCity}. Flexible single sessions, multi-session packs, and monthly programmes.`,
 };
 
 export default function PricingPage() {

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next';
 import { Testimonials } from '@/components/Testimonials';
 import { CTAButton } from '@/components/CTAButton';
+import { siteConfig } from '@/content/site';
 import { testimonials } from '@/content/testimonials';
-import { env } from '@/lib/env';
 
 export const metadata: Metadata = {
   title: 'Results',
-  description: `See real results from ${env.coachName}'s bouldering coaching. Testimonials, progress stories, and client achievements.`,
+  description: `See real results from ${siteConfig.coachName}'s bouldering coaching. Testimonials, progress stories, and client achievements.`,
 };
 
 export default function ResultsPage() {
@@ -43,9 +43,7 @@ export default function ResultsPage() {
                       {t.afterGrade}
                     </span>
                   </div>
-                  {t.duration && (
-                    <p className="text-xs text-slate-500">in {t.duration}</p>
-                  )}
+                  {t.duration && <p className="text-xs text-slate-500">in {t.duration}</p>}
                 </div>
               ))}
           </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { siteConfig } from '@/content/site';
 import { env } from '@/lib/env';
 
 export function Footer() {
@@ -13,8 +14,8 @@ export function Footer() {
               Boulder Daddy
             </h3>
             <p className="text-sm text-slate-600">
-              Professional bouldering coaching in {env.coachCity}. Helping climbers of all levels
-              move better, climb harder, and stay injury-free.
+              Professional bouldering coaching in {siteConfig.coachCity}. Helping climbers of all
+              levels move better, climb harder, and stay injury-free.
             </p>
           </div>
 
@@ -67,8 +68,8 @@ export function Footer() {
                 </a>
               </li>
               <li>
-                <a href={`mailto:${env.coachEmail}`} className="hover:text-slate-900">
-                  {env.coachEmail}
+                <a href={`mailto:${siteConfig.coachEmail}`} className="hover:text-slate-900">
+                  {siteConfig.coachEmail}
                 </a>
               </li>
             </ul>
@@ -89,7 +90,7 @@ export function Footer() {
         </div>
 
         <div className="mt-8 border-t border-slate-200 pt-8 text-center text-sm text-slate-500">
-          © {year} {env.coachName}. All rights reserved.
+          © {year} {siteConfig.coachName}. All rights reserved.
         </div>
       </div>
     </footer>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,7 +11,7 @@ export function Footer() {
         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
           <div>
             <h3 className="mb-3 text-sm font-bold uppercase tracking-wider text-slate-900">
-              Boulder Daddy
+              {siteConfig.brandName}
             </h3>
             <p className="text-sm text-slate-600">
               Professional bouldering coaching in {siteConfig.coachCity}. Helping climbers of all
@@ -90,7 +90,7 @@ export function Footer() {
         </div>
 
         <div className="mt-8 border-t border-slate-200 pt-8 text-center text-sm text-slate-500">
-          © {year} {siteConfig.coachName}. All rights reserved.
+          © {year} {siteConfig.brandName}. All rights reserved.
         </div>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { siteConfig } from '@/content/site';
 import { cn } from '@/lib/cn';
 import { CTAButton } from './CTAButton';
 
@@ -20,7 +21,7 @@ export function Header() {
     <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/90 backdrop-blur-md">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
         <Link href="/" className="text-xl font-bold tracking-tight text-slate-900">
-          Boulder Daddy
+          {siteConfig.brandName}
         </Link>
 
         {/* Desktop nav */}

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -1,10 +1,12 @@
 export interface SiteConfig {
+  brandName: string;
   coachName: string;
   coachCity: string;
   coachEmail: string;
 }
 
 export const siteConfig = {
+  brandName: 'mathemage',
   coachName: 'Mgr. Karel Ha',
   coachCity: 'Prague/Pilsen, Czech Republic',
   coachEmail: 'bouldertatka@gmail.com',

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -1,0 +1,11 @@
+export interface SiteConfig {
+  coachName: string;
+  coachCity: string;
+  coachEmail: string;
+}
+
+export const siteConfig = {
+  coachName: 'Mgr. Karel Ha',
+  coachCity: 'Prague/Pilsen, Czech Republic',
+  coachEmail: 'bouldertatka@gmail.com',
+} satisfies SiteConfig;

--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -1,4 +1,4 @@
-import { env } from '@/lib/env';
+import { siteConfig } from '@/content/site';
 
 export interface EmailPayload {
   name: string;
@@ -18,7 +18,7 @@ export async function sendContactEmail(payload: EmailPayload): Promise<{ success
   // const resend = new Resend(process.env.RESEND_API_KEY);
   // await resend.emails.send({
   //   from: 'noreply@yourdomain.com',
-  //   to: env.coachEmail,
+  //   to: siteConfig.coachEmail,
   //   subject: `New coaching inquiry from ${payload.name}`,
   //   text: formatEmail(payload),
   // });
@@ -35,7 +35,7 @@ export async function sendContactEmail(payload: EmailPayload): Promise<{ success
     console.log(`Goals: ${payload.goals}`);
     console.log(`Preferred Days: ${payload.preferredDays.join(', ')}`);
     console.log(`Message: ${payload.message}`);
-    console.log(`Would be sent to: ${env.coachEmail}`);
+    console.log(`Would be sent to: ${siteConfig.coachEmail}`);
     console.log('───────────────────────────────────');
     return { success: true };
   }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,8 +1,7 @@
+// Keep environment-specific settings and secrets here.
+// Public coach profile values live in src/content/site.ts so they can be versioned.
 export const env = {
   siteUrl: process.env.SITE_URL || 'http://localhost:3000',
-  coachName: process.env.COACH_NAME || 'Boulder Daddy',
-  coachCity: process.env.COACH_CITY || 'Your City',
-  coachEmail: process.env.COACH_EMAIL || 'coach@example.com',
   coachIgUsername: process.env.COACH_IG_USERNAME || 'boulder_daddy',
   bookingUrl: process.env.BOOKING_URL || '',
   instagram: {


### PR DESCRIPTION
## Summary
- move the public coach name, city, and email into tracked `src/content/site.ts`
- keep `.env.example` and `src/lib/env.ts` focused on environment-specific settings and secrets
- update pages, metadata, README, and email comments/docs to use the tracked site config

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Notes
- `pnpm format:check` still reports pre-existing formatting issues in unrelated untouched files

Closes #15