### PR TITLE
chore(config): Update README title and env values #18

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Keep only environment-specific values and secrets in .env.local.
 
 # Site
-SITE_URL=https://boulder-daddy.vercel.app/
+SITE_URL=https://boulder-daddy.vercel.app
 COACH_IG_USERNAME=mathemage
 BOOKING_URL=https://calendar.app.google/CUTBE7hcFyrJPbU17
 

--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,9 @@
 # Keep only environment-specific values and secrets in .env.local.
 
 # Site
-SITE_URL=http://localhost:3000
-COACH_IG_USERNAME=your_ig_handle
-BOOKING_URL=
+SITE_URL=https://boulder-daddy.vercel.app/
+COACH_IG_USERNAME=mathemage
+BOOKING_URL=https://calendar.app.google/CUTBE7hcFyrJPbU17
 
 # Instagram integration
 # Options: manual | proxy | graph

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,5 @@
-# Public coach profile values live in src/content/site.ts so they can be committed.
+# Public site and coach values live in src/content/site.ts so they can be committed.
 # Keep only environment-specific values and secrets in .env.local.
-
-# Site
-SITE_URL=https://boulder-daddy.vercel.app
-COACH_IG_USERNAME=mathemage
-BOOKING_URL=https://calendar.app.google/CUTBE7hcFyrJPbU17
 
 # Instagram integration
 # Options: manual | proxy | graph

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Public site and coach values (brand name, coach name, city, email, site URL, Ins
 
 | Variable                       | Required | Description                                                           |
 | ------------------------------ | -------- | --------------------------------------------------------------------- |
-| `INSTAGRAM_MODE`               | Yes      | `manual`, `proxy`, or `graph`                                         |
+| `INSTAGRAM_MODE`               | No       | `manual`, `proxy`, or `graph` (default: `manual`)                     |
 | `INSTAGRAM_MANUAL_JSON_PATH`   | No       | Path to manual Instagram JSON (default: `src/content/instagram.json`) |
 | `INSTAGRAM_PROXY_URL`          | No       | URL for RSS/JSON proxy (when mode is `proxy`)                         |
 | `INSTAGRAM_GRAPH_ACCESS_TOKEN` | No       | Instagram Graph API token (when mode is `graph`)                      |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ src/
 │   └── ContactForm.tsx     # Contact form with validation
 ├── content/                # Content data (easy to edit)
 │   ├── services.ts         # Coaching offerings
-│   ├── site.ts             # Public coach profile data
+│   ├── site.ts             # Public site and coach data
 │   ├── pricing.ts          # Pricing tiers
 │   ├── testimonials.ts     # Client testimonials
 │   ├── faqs.ts             # FAQ entries
@@ -97,21 +97,18 @@ src/
 
 ## Configuration
 
-Copy `.env.example` to `.env.local` and update the environment-specific values:
+Copy `.env.example` to `.env.local` and update any environment-specific values you need:
 
 ```bash
 cp .env.example .env.local
 ```
 
-Public branding and coach profile values (brand name, coach name, city, and email) live in `src/content/site.ts` so they can be versioned with the rest of your site content.
+Public site and coach values (brand name, coach name, city, email, site URL, Instagram handle, and booking URL) live in `src/content/site.ts` so they can be versioned with the rest of your site content.
 
 ### Environment Variables
 
 | Variable                       | Required | Description                                                           |
 | ------------------------------ | -------- | --------------------------------------------------------------------- |
-| `SITE_URL`                     | Yes      | Your site URL (e.g., `https://yourdomain.com`)                        |
-| `COACH_IG_USERNAME`            | Yes      | Your Instagram handle                                                 |
-| `BOOKING_URL`                  | No       | External booking link (shows "Book a Session" button if set)          |
 | `INSTAGRAM_MODE`               | Yes      | `manual`, `proxy`, or `graph`                                         |
 | `INSTAGRAM_MANUAL_JSON_PATH`   | No       | Path to manual Instagram JSON (default: `src/content/instagram.json`) |
 | `INSTAGRAM_PROXY_URL`          | No       | URL for RSS/JSON proxy (when mode is `proxy`)                         |
@@ -153,7 +150,7 @@ If proxy or Graph API calls fail, the service automatically falls back to manual
 
 All site content lives in `src/content/`:
 
-- **Site profile**: Edit `site.ts` to set your public brand name, coach name, city, and email
+- **Site profile**: Edit `site.ts` to set your public brand name, coach name, city, email, site URL, Instagram handle, and booking URL
 - **Services**: Edit `services.ts` to add/remove/modify coaching offerings
 - **Pricing**: Edit `pricing.ts` to update tiers and features
 - **Testimonials**: Edit `testimonials.ts` to add client stories

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mathemage
+# boulder-daddy: Professional website for coaching and teaching bouldering/climbing by @mathemage
 
 [![CI](https://github.com/mathemage/boulder-daddy/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mathemage/boulder-daddy/actions/workflows/ci.yml)
 [![Code: Apache-2.0](https://img.shields.io/badge/Code-Apache%202.0-blue.svg)](https://choosealicense.com/licenses/apache-2.0/)

--- a/src/__tests__/site-config.test.ts
+++ b/src/__tests__/site-config.test.ts
@@ -10,6 +10,10 @@ describe('site config', () => {
     expect(normalizeSiteUrl('https://example.com')).toBe('https://example.com');
   });
 
+  it('trims surrounding whitespace and multiple trailing slashes', () => {
+    expect(normalizeSiteUrl('  https://example.com///  ')).toBe('https://example.com');
+  });
+
   it('exports a normalized canonical site URL', () => {
     expect(normalizedSiteUrl).toBe(siteConfig.siteUrl);
     expect(normalizedSiteUrl.endsWith('/')).toBe(false);

--- a/src/__tests__/site-config.test.ts
+++ b/src/__tests__/site-config.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSiteUrl, normalizedSiteUrl, siteConfig } from '@/content/site';
+
+describe('site config', () => {
+  it('normalizes a trailing slash from a site URL', () => {
+    expect(normalizeSiteUrl('https://example.com/')).toBe('https://example.com');
+  });
+
+  it('preserves a site URL without a trailing slash', () => {
+    expect(normalizeSiteUrl('https://example.com')).toBe('https://example.com');
+  });
+
+  it('exports a normalized canonical site URL', () => {
+    expect(normalizedSiteUrl).toBe(siteConfig.siteUrl);
+    expect(normalizedSiteUrl.endsWith('/')).toBe(false);
+  });
+});

--- a/src/__tests__/site-config.test.ts
+++ b/src/__tests__/site-config.test.ts
@@ -15,7 +15,7 @@ describe('site config', () => {
   });
 
   it('exports a normalized canonical site URL', () => {
-    expect(normalizedSiteUrl).toBe(siteConfig.siteUrl);
+    expect(normalizedSiteUrl).toBe(normalizeSiteUrl(siteConfig.siteUrl));
     expect(normalizedSiteUrl.endsWith('/')).toBe(false);
   });
 });

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import { ContactForm } from '@/components/ContactForm';
 import { siteConfig } from '@/content/site';
-import { env } from '@/lib/env';
 
 export const metadata: Metadata = {
   title: 'Contact',
@@ -34,23 +33,23 @@ export default function ContactPage() {
             <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
               <h3 className="mb-1 text-sm font-bold text-slate-900">Instagram</h3>
               <a
-                href={`https://instagram.com/${env.coachIgUsername}`}
+                href={`https://instagram.com/${siteConfig.coachIgUsername}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-sm text-slate-600 hover:text-slate-900"
               >
-                @{env.coachIgUsername}
+                @{siteConfig.coachIgUsername}
               </a>
             </div>
           </div>
 
-          {env.bookingUrl && (
+          {siteConfig.bookingUrl && (
             <div className="mb-8 rounded-lg border border-slate-200 bg-slate-50 p-4 text-center">
               <p className="mb-2 text-sm text-slate-600">
                 Prefer to book directly? Use my scheduling link:
               </p>
               <a
-                href={env.bookingUrl}
+                href={siteConfig.bookingUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-block rounded-lg bg-slate-900 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
-import { siteConfig } from '@/content/site';
+import { normalizedSiteUrl, siteConfig } from '@/content/site';
 import './globals.css';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(siteConfig.siteUrl),
+  metadataBase: new URL(normalizedSiteUrl),
   title: {
     default: `${siteConfig.brandName} — Bouldering Coach in ${siteConfig.coachCity}`,
     template: `%s | ${siteConfig.brandName}`,
@@ -32,7 +32,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     name: siteConfig.coachName,
     alternateName: siteConfig.brandName,
     description: `Professional bouldering coach in ${siteConfig.coachCity}`,
-    url: siteConfig.siteUrl,
+    url: normalizedSiteUrl,
     email: siteConfig.coachEmail,
     address: {
       '@type': 'PostalAddress',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,11 +2,10 @@ import type { Metadata } from 'next';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
 import { siteConfig } from '@/content/site';
-import { env } from '@/lib/env';
 import './globals.css';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(env.siteUrl),
+  metadataBase: new URL(siteConfig.siteUrl),
   title: {
     default: `${siteConfig.brandName} — Bouldering Coach in ${siteConfig.coachCity}`,
     template: `%s | ${siteConfig.brandName}`,
@@ -33,13 +32,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     name: siteConfig.coachName,
     alternateName: siteConfig.brandName,
     description: `Professional bouldering coach in ${siteConfig.coachCity}`,
-    url: env.siteUrl,
+    url: siteConfig.siteUrl,
     email: siteConfig.coachEmail,
     address: {
       '@type': 'PostalAddress',
       addressLocality: siteConfig.coachCity,
     },
-    sameAs: [`https://instagram.com/${env.coachIgUsername}`],
+    sameAs: [`https://instagram.com/${siteConfig.coachIgUsername}`],
   };
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,6 @@ import { InstagramGallery } from '@/components/InstagramGallery';
 import { Testimonials } from '@/components/Testimonials';
 import { CTAButton } from '@/components/CTAButton';
 import { siteConfig } from '@/content/site';
-import { env } from '@/lib/env';
 import { getInstagramPosts } from '@/lib/instagram';
 
 export default async function HomePage() {
@@ -14,7 +13,7 @@ export default async function HomePage() {
     <>
       <Hero coachCity={siteConfig.coachCity} />
       <ServiceCards />
-      <InstagramGallery posts={posts} coachIgUsername={env.coachIgUsername} />
+      <InstagramGallery posts={posts} coachIgUsername={siteConfig.coachIgUsername} />
       <Testimonials />
 
       {/* CTA Section */}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next';
-import { env } from '@/lib/env';
+import { siteConfig } from '@/content/site';
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -8,6 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: '/',
       disallow: '/api/',
     },
-    sitemap: `${env.siteUrl}/sitemap.xml`,
+    sitemap: `${siteConfig.siteUrl}/sitemap.xml`,
   };
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next';
-import { siteConfig } from '@/content/site';
+import { normalizedSiteUrl } from '@/content/site';
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -8,6 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: '/',
       disallow: '/api/',
     },
-    sitemap: `${siteConfig.siteUrl}/sitemap.xml`,
+    sitemap: `${normalizedSiteUrl}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,8 @@
 import type { MetadataRoute } from 'next';
-import { siteConfig } from '@/content/site';
+import { normalizedSiteUrl } from '@/content/site';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = siteConfig.siteUrl;
+  const baseUrl = normalizedSiteUrl;
 
   return [
     { url: baseUrl, lastModified: new Date(), changeFrequency: 'weekly', priority: 1.0 },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,8 @@
 import type { MetadataRoute } from 'next';
-import { env } from '@/lib/env';
+import { siteConfig } from '@/content/site';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = env.siteUrl;
+  const baseUrl = siteConfig.siteUrl;
 
   return [
     { url: baseUrl, lastModified: new Date(), changeFrequency: 'weekly', priority: 1.0 },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import { siteConfig } from '@/content/site';
-import { env } from '@/lib/env';
 
 export function Footer() {
   const year = new Date().getFullYear();
@@ -59,7 +58,7 @@ export function Footer() {
               </li>
               <li>
                 <a
-                  href={`https://instagram.com/${env.coachIgUsername}`}
+                  href={`https://instagram.com/${siteConfig.coachIgUsername}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="hover:text-slate-900"

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -17,3 +17,9 @@ export const siteConfig = {
   coachIgUsername: 'mathemage',
   bookingUrl: 'https://calendar.app.google/CUTBE7hcFyrJPbU17',
 } satisfies SiteConfig;
+
+export function normalizeSiteUrl(siteUrl: string): string {
+  return siteUrl.replace(/\/$/, '');
+}
+
+export const normalizedSiteUrl = normalizeSiteUrl(siteConfig.siteUrl);

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -19,7 +19,7 @@ export const siteConfig = {
 } satisfies SiteConfig;
 
 export function normalizeSiteUrl(siteUrl: string): string {
-  return siteUrl.replace(/\/$/, '');
+  return siteUrl.trim().replace(/\/+$/, '');
 }
 
 export const normalizedSiteUrl = normalizeSiteUrl(siteConfig.siteUrl);

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -3,6 +3,9 @@ export interface SiteConfig {
   coachName: string;
   coachCity: string;
   coachEmail: string;
+  siteUrl: string;
+  coachIgUsername: string;
+  bookingUrl: string;
 }
 
 export const siteConfig = {
@@ -10,4 +13,7 @@ export const siteConfig = {
   coachName: 'Mgr. Karel Ha',
   coachCity: 'Prague/Pilsen, Czech Republic',
   coachEmail: 'bouldertatka@gmail.com',
+  siteUrl: 'https://boulder-daddy.vercel.app',
+  coachIgUsername: 'mathemage',
+  bookingUrl: 'https://calendar.app.google/CUTBE7hcFyrJPbU17',
 } satisfies SiteConfig;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,9 +1,6 @@
 // Keep environment-specific settings and secrets here.
-// Public coach profile values live in src/content/site.ts so they can be versioned.
+// Public site and coach values live in src/content/site.ts so they can be versioned.
 export const env = {
-  siteUrl: process.env.SITE_URL || 'http://localhost:3000',
-  coachIgUsername: process.env.COACH_IG_USERNAME || 'boulder_daddy',
-  bookingUrl: process.env.BOOKING_URL || '',
   instagram: {
     mode: (process.env.INSTAGRAM_MODE || 'manual') as 'manual' | 'proxy' | 'graph',
     manualJsonPath: process.env.INSTAGRAM_MANUAL_JSON_PATH || 'src/content/instagram.json',


### PR DESCRIPTION
## Summary
- update the README title to the requested repository heading
- move the public site URL, Instagram handle, and booking URL into tracked `src/content/site.ts`
- keep `.env.example` focused on environment-specific settings and secrets
- normalize the canonical site URL before deriving sitemap, robots, and metadata URLs

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm build`

Closes #18